### PR TITLE
[PR] Use home_url() and force trailing slash for CSS previews

### DIFF
--- a/custom-css.php
+++ b/custom-css.php
@@ -82,7 +82,7 @@ class Jetpack_Custom_CSS {
 			) );
 
 			if ( $_POST['action'] == 'preview' ) {
-				wp_safe_redirect( add_query_arg( 'csspreview', 'true', get_option( 'home' ) ) );
+				wp_safe_redirect( add_query_arg( 'csspreview', 'true', trailingslashit( home_url() ) ) );
 				exit;
 			}
 


### PR DESCRIPTION
WordPress strips trailing slashes during site creation when the
options for home and site are stored. This can break the preview
for CSS on some sites because the URL is not interpreted correctly
