### PR TITLE
[Pr] Enqueue styles above scripts when Spine theme is used

### DIFF
--- a/custom-css.php
+++ b/custom-css.php
@@ -60,7 +60,14 @@ class WSU_Custom_CSS {
 		}
 
 		add_action( 'admin_enqueue_scripts', array( 'WSU_Custom_CSS', 'enqueue_scripts'       )        );
-		add_action( 'wp_head',               array( 'WSU_Custom_CSS', 'link_tag'              ), 101   );
+
+		$current_theme = wp_get_theme();
+
+		if ( 'spine' === $current_theme->template ) {
+			add_action( 'spine_enqueue_styles', array( 'WSU_Custom_CSS', 'link_tag' ), 10 );
+		} else {
+			add_action( 'wp_head',               array( 'WSU_Custom_CSS', 'link_tag'              ), 101   );
+		}
 
 		if ( !current_user_can( 'switch_themes' ) && !is_super_admin() ) {
 			return;
@@ -542,9 +549,19 @@ class WSU_Custom_CSS {
 		if ( WSU_Custom_CSS::is_preview() ) {
 			$href = add_query_arg( 'csspreview', 'true', $href );
 		}
-		?>
-		<link rel="stylesheet" id="custom-css-css" type="text/css" href="<?php echo esc_url( $href ); ?>" />
-		<?php
+
+		$current_theme = wp_get_theme();
+
+		// We plan on the style being enqueued in the Spine parent theme. This should be considered temporary
+		// until we can rewrite to handle more than the Spine theme.
+		if ( 'spine' === $current_theme->template ) {
+			wp_enqueue_style( 'spine-custom-css', esc_url( $href ), array(), spine_get_script_version() );
+		} else {
+			?>
+			<link rel="stylesheet" id="custom-css-css" type="text/css" href="<?php echo esc_url( $href ); ?>" />
+			<?php
+		}
+
 
 		do_action( 'safecss_link_tag_post' );
 	}


### PR DESCRIPTION
By default, Custom CSS output the CSS link on wp_head, which meant
that the one style would be provided to the browser after a bunch
of enqueued scripts. This could cause delays in styling the DOM.

The new way is also more sane. :)
