### PR TITLE
[PR] Add SVG fill property as an accepted CSS 3.0 property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2.1.1 (August 27, 2014)
+
+* Add SVG `fill` property as an accepted CSS 3.0 property.

--- a/csstidy/data.inc.php
+++ b/csstidy/data.inc.php
@@ -396,6 +396,7 @@ $GLOBALS['csstidy']['all_properties']['drop-initial-size'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['drop-initial-value'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['elevation'] = 'CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['empty-cells'] = 'CSS2.0,CSS2.1,CSS3.0';
+$GLOBALS['csstidy']['all_properties']['fill'] = 'CSS3.0'; // This is really SVG, not CSS 3.0.
 $GLOBALS['csstidy']['all_properties']['fit'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['fit-position'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['flex-align'] = 'CSS3.0';


### PR DESCRIPTION
This isn't entirely valid, though it is used just like any other property. At some point it may be nice to handle this kind of thing outside of the plugin.
